### PR TITLE
Fix it so that tree shaking works correctly.

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,16 +1,29 @@
 {
-    "presets": [
+  "presets": [
+    [
       "@babel/preset-env",
-      "@babel/preset-react"
+      {
+        "targets": {
+          "esmodules": true
+        }
+      }
     ],
-    "plugins": [
-      ["@babel/plugin-proposal-class-properties",
-      {
-        "loose": true
-      }],
-      ["@babel/plugin-proposal-private-methods",
-      {
-        "loose": true
-      }]
+    [
+      "@babel/preset-react"
     ]
-  }
+  ],
+  "plugins": [
+    [
+      "@babel/plugin-proposal-class-properties",
+      {
+        "loose": true
+      }
+    ],
+    [
+      "@babel/plugin-proposal-private-methods",
+      {
+        "loose": true
+      }
+    ]
+  ]
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -2319,16 +2319,6 @@
         "stylelint-declaration-strict-value": "^1.1.3"
       }
     },
-    "@instructure/ui-stylesheet": {
-      "version": "7.5.1",
-      "resolved": "https://registry.npmjs.org/@instructure/ui-stylesheet/-/ui-stylesheet-7.5.1.tgz",
-      "integrity": "sha512-kWiwzZHvSq43tIkbJ9QTfeGpPYSkJTZAaDI9A57Q5AGcQaJE6zlQT9OwTMMJcLMjHJlFuiiHfmeyvA189Gtn9A==",
-      "dev": true,
-      "requires": {
-        "@babel/runtime": "^7.9.2",
-        "glamor": "^2.20.40"
-      }
-    },
     "@instructure/ui-svg-images": {
       "version": "8.4.0",
       "resolved": "https://registry.npmjs.org/@instructure/ui-svg-images/-/ui-svg-images-8.4.0.tgz",
@@ -2361,144 +2351,6 @@
       "dev": true,
       "requires": {
         "@babel/runtime": "^7.13.10"
-      }
-    },
-    "@instructure/ui-themeable": {
-      "version": "7.5.1",
-      "resolved": "https://registry.npmjs.org/@instructure/ui-themeable/-/ui-themeable-7.5.1.tgz",
-      "integrity": "sha512-jmSjUYw9inkBRvj1TH82FN9tPeoRifUuqg4DIsfJfGr8M/30x4HL2Gi3TAyBWQTQXli/ODiHiJIVlKBXZ08DOw==",
-      "dev": true,
-      "requires": {
-        "@babel/runtime": "^7.9.2",
-        "@instructure/console": "^7.5.1",
-        "@instructure/ui-color-utils": "^7.5.1",
-        "@instructure/ui-decorator": "^7.5.1",
-        "@instructure/ui-dom-utils": "^7.5.1",
-        "@instructure/ui-react-utils": "^7.5.1",
-        "@instructure/ui-stylesheet": "^7.5.1",
-        "@instructure/ui-utils": "^7.5.1",
-        "@instructure/uid": "^7.5.1",
-        "prop-types": "^15"
-      },
-      "dependencies": {
-        "@emotion/is-prop-valid": {
-          "version": "0.8.8",
-          "resolved": "https://registry.npmjs.org/@emotion/is-prop-valid/-/is-prop-valid-0.8.8.tgz",
-          "integrity": "sha512-u5WtneEAr5IDG2Wv65yhunPSMLIpuKsbuOktRojfrEiEvRyC85LgPMZI63cr7NUqT8ZIGdSVg8ZKGxIug4lXcA==",
-          "dev": true,
-          "requires": {
-            "@emotion/memoize": "0.7.4"
-          }
-        },
-        "@emotion/memoize": {
-          "version": "0.7.4",
-          "resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.7.4.tgz",
-          "integrity": "sha512-Ja/Vfqe3HpuzRsG1oBtWTHk2PGZ7GR+2Vz5iYGelAw8dx32K0y7PjVuxK6z1nMpZOqAFsRUPCkK1YjJ56qJlgw==",
-          "dev": true
-        },
-        "@instructure/console": {
-          "version": "7.7.0",
-          "resolved": "https://registry.npmjs.org/@instructure/console/-/console-7.7.0.tgz",
-          "integrity": "sha512-3qdhWlvnNSniiBlD4sH5FznU2EAhCVjvrZ6nnfoiYfnr0kcdZ9pARdJoB0QsXfiROKdpmNV93jmmhEmdX7NKuw==",
-          "dev": true,
-          "requires": {
-            "@babel/helper-annotate-as-pure": "^7.8.3",
-            "@babel/helper-module-imports": "^7.8.3",
-            "babel-plugin-macros": "^2.8.0"
-          }
-        },
-        "@instructure/ui-color-utils": {
-          "version": "7.7.0",
-          "resolved": "https://registry.npmjs.org/@instructure/ui-color-utils/-/ui-color-utils-7.7.0.tgz",
-          "integrity": "sha512-AosKhaQxxwBGvWQ66dGWL3pkv7a5DgkdCSNU5Js5VQFeegTjYyKUazV3MWEeuxuPjJpQxojKixxwXXIx+O/NqQ==",
-          "dev": true,
-          "requires": {
-            "@babel/runtime": "^7.9.2",
-            "tinycolor2": "^1.4.1"
-          }
-        },
-        "@instructure/ui-decorator": {
-          "version": "7.7.0",
-          "resolved": "https://registry.npmjs.org/@instructure/ui-decorator/-/ui-decorator-7.7.0.tgz",
-          "integrity": "sha512-q2dtEBvT4z4CkuQDSEVSUbWP16hgkn0ClfP+tsRW6v/BY1jgheioTlaM3olzL/o8rvzw0TZBcTZiOGdL1OWxsQ==",
-          "dev": true,
-          "requires": {
-            "@babel/runtime": "^7.9.2"
-          }
-        },
-        "@instructure/ui-dom-utils": {
-          "version": "7.7.0",
-          "resolved": "https://registry.npmjs.org/@instructure/ui-dom-utils/-/ui-dom-utils-7.7.0.tgz",
-          "integrity": "sha512-bJDAD3lYSU70HSxML3tucPEdpwfeSDC1PHZLLNcWxb82vdvjJwSk6Jh/i/eUH2lrB9kDTwDTLDzHtpJlXejyQg==",
-          "dev": true,
-          "requires": {
-            "@babel/runtime": "^7.9.2",
-            "@instructure/console": "^7.7.0"
-          }
-        },
-        "@instructure/ui-react-utils": {
-          "version": "7.7.0",
-          "resolved": "https://registry.npmjs.org/@instructure/ui-react-utils/-/ui-react-utils-7.7.0.tgz",
-          "integrity": "sha512-kGIc41+uwanxI+RJnFlsIjVw5Khzjwn6l/ZUh88VBTMcVB44ovYIu12RBg0gGQN42pDE3rMruLTB4UVPY4gIfQ==",
-          "dev": true,
-          "requires": {
-            "@babel/runtime": "^7.9.2",
-            "@emotion/is-prop-valid": "^0.8.3",
-            "@instructure/console": "^7.7.0",
-            "@instructure/ui-decorator": "^7.7.0",
-            "@instructure/ui-dom-utils": "^7.7.0",
-            "@instructure/ui-utils": "^7.7.0",
-            "prop-types": "^15"
-          }
-        },
-        "@instructure/ui-utils": {
-          "version": "7.7.0",
-          "resolved": "https://registry.npmjs.org/@instructure/ui-utils/-/ui-utils-7.7.0.tgz",
-          "integrity": "sha512-wjI2ZFpiexGwDztQSsK4VWjIZ5BkIG657B2HaYHgBZe2D4Wz/TVOIzMVRsllKLCvjS9pUYHOSO9rnMFj5OcP1A==",
-          "dev": true,
-          "requires": {
-            "@babel/runtime": "^7.9.2",
-            "@instructure/console": "^7.7.0",
-            "@instructure/ui-dom-utils": "^7.7.0",
-            "bowser": "^1.9.4",
-            "fast-deep-equal": "^2",
-            "json-stable-stringify": "^1.0.1",
-            "keycode": "^2"
-          }
-        },
-        "@instructure/uid": {
-          "version": "7.7.0",
-          "resolved": "https://registry.npmjs.org/@instructure/uid/-/uid-7.7.0.tgz",
-          "integrity": "sha512-C/K18HttuRepZxQX0E+/wwqyF2FXyt8lbxieVQu9QMd5hOKeKGqFSuWQS0DGsD9+EtxkTuYjLIdvdq5I6CCzkQ==",
-          "dev": true,
-          "requires": {
-            "@babel/runtime": "^7.9.2"
-          }
-        },
-        "babel-plugin-macros": {
-          "version": "2.8.0",
-          "resolved": "https://registry.npmjs.org/babel-plugin-macros/-/babel-plugin-macros-2.8.0.tgz",
-          "integrity": "sha512-SEP5kJpfGYqYKpBrj5XU3ahw5p5GOHJ0U5ssOSQ/WBVdwkD2Dzlce95exQTs3jOVWPPKLBN2rlEWkCK7dSmLvg==",
-          "dev": true,
-          "requires": {
-            "@babel/runtime": "^7.7.2",
-            "cosmiconfig": "^6.0.0",
-            "resolve": "^1.12.0"
-          }
-        },
-        "cosmiconfig": {
-          "version": "6.0.0",
-          "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-6.0.0.tgz",
-          "integrity": "sha512-xb3ZL6+L8b9JLLCx3ZdoZy4+2ECphCMo2PwqgP1tlfVq6M6YReyzBJtvWWtbDSpNr9hn96pkCiZqUcFEc+54Qg==",
-          "dev": true,
-          "requires": {
-            "@types/parse-json": "^4.0.0",
-            "import-fresh": "^3.1.0",
-            "parse-json": "^5.0.0",
-            "path-type": "^4.0.0",
-            "yaml": "^1.7.2"
-          }
-        }
       }
     },
     "@instructure/ui-themes": {
@@ -6380,12 +6232,6 @@
       "integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=",
       "dev": true
     },
-    "asap": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
-      "integrity": "sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY=",
-      "dev": true
-    },
     "asn1.js": {
       "version": "5.4.1",
       "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-5.4.1.tgz",
@@ -8699,16 +8545,6 @@
       "integrity": "sha1-gIrcLnnPhHOAabZGyyDsJ762KeA=",
       "dev": true
     },
-    "css-in-js-utils": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/css-in-js-utils/-/css-in-js-utils-2.0.1.tgz",
-      "integrity": "sha512-PJF0SpJT+WdbVVt0AOYp9C8GnuruRlL/UFW7932nLWmFLQTaWEzTBQEx7/hn4BuV+WON75iAViSUJLiU3PKbpA==",
-      "dev": true,
-      "requires": {
-        "hyphenate-style-name": "^1.0.2",
-        "isobject": "^3.0.1"
-      }
-    },
     "css-loader": {
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/css-loader/-/css-loader-3.6.0.tgz",
@@ -9441,26 +9277,6 @@
       "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
       "integrity": "sha1-rT/0yG7C0CkyL1oCw6mmBslbP1k=",
       "dev": true
-    },
-    "encoding": {
-      "version": "0.1.13",
-      "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.13.tgz",
-      "integrity": "sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A==",
-      "dev": true,
-      "requires": {
-        "iconv-lite": "^0.6.2"
-      },
-      "dependencies": {
-        "iconv-lite": {
-          "version": "0.6.3",
-          "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
-          "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
-          "dev": true,
-          "requires": {
-            "safer-buffer": ">= 2.1.2 < 3.0.0"
-          }
-        }
-      }
     },
     "end-of-stream": {
       "version": "1.4.4",
@@ -10608,29 +10424,6 @@
         "bser": "2.1.1"
       }
     },
-    "fbjs": {
-      "version": "0.8.17",
-      "resolved": "https://registry.npmjs.org/fbjs/-/fbjs-0.8.17.tgz",
-      "integrity": "sha1-xNWY6taUkRJlPWWIsBpc3Nn5D90=",
-      "dev": true,
-      "requires": {
-        "core-js": "^1.0.0",
-        "isomorphic-fetch": "^2.1.1",
-        "loose-envify": "^1.0.0",
-        "object-assign": "^4.1.0",
-        "promise": "^7.1.1",
-        "setimmediate": "^1.0.5",
-        "ua-parser-js": "^0.7.18"
-      },
-      "dependencies": {
-        "core-js": {
-          "version": "1.2.7",
-          "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.7.tgz",
-          "integrity": "sha1-ZSKUwUZR2yj6k70tX/KYOk8IxjY=",
-          "dev": true
-        }
-      }
-    },
     "figgy-pudding": {
       "version": "3.5.2",
       "resolved": "https://registry.npmjs.org/figgy-pudding/-/figgy-pudding-3.5.2.tgz",
@@ -11193,19 +10986,6 @@
           "integrity": "sha1-xs0OwbBkLio8Z6ETfvxeeW2k+I4=",
           "dev": true
         }
-      }
-    },
-    "glamor": {
-      "version": "2.20.40",
-      "resolved": "https://registry.npmjs.org/glamor/-/glamor-2.20.40.tgz",
-      "integrity": "sha512-DNXCd+c14N9QF8aAKrfl4xakPk5FdcFwmH7sD0qnC0Pr7xoZ5W9yovhUrY/dJc3psfGGXC58vqQyRtuskyUJxA==",
-      "dev": true,
-      "requires": {
-        "fbjs": "^0.8.12",
-        "inline-style-prefixer": "^3.0.6",
-        "object-assign": "^4.1.1",
-        "prop-types": "^15.5.10",
-        "through": "^2.3.8"
       }
     },
     "glob": {
@@ -11932,12 +11712,6 @@
       "integrity": "sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==",
       "dev": true
     },
-    "hyphenate-style-name": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/hyphenate-style-name/-/hyphenate-style-name-1.0.4.tgz",
-      "integrity": "sha512-ygGZLjmXfPHj+ZWh6LwbC37l43MhfztxetbFCoYTM2VjkIUpeHgSNn7QIyVFj7YQ1Wl9Cbw5sholVJPzWvC2MQ==",
-      "dev": true
-    },
     "iconv-lite": {
       "version": "0.4.24",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
@@ -12042,16 +11816,6 @@
       "resolved": "https://registry.npmjs.org/inline-style-parser/-/inline-style-parser-0.1.1.tgz",
       "integrity": "sha512-7NXolsK4CAS5+xvdj5OMMbI962hU/wvwoxk+LWR9Ek9bVtyuuYScDN6eS0rUm6TxApFpw7CX1o4uJzcd4AyD3Q==",
       "dev": true
-    },
-    "inline-style-prefixer": {
-      "version": "3.0.8",
-      "resolved": "https://registry.npmjs.org/inline-style-prefixer/-/inline-style-prefixer-3.0.8.tgz",
-      "integrity": "sha1-hVG45bTVcyROZqNLBPfTIHaitTQ=",
-      "dev": true,
-      "requires": {
-        "bowser": "^1.7.3",
-        "css-in-js-utils": "^2.0.0"
-      }
     },
     "internal-slot": {
       "version": "1.0.3",
@@ -12507,34 +12271,6 @@
       "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
       "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
       "dev": true
-    },
-    "isomorphic-fetch": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/isomorphic-fetch/-/isomorphic-fetch-2.2.1.tgz",
-      "integrity": "sha1-YRrhrPFPXoH3KVB0coGf6XM1WKk=",
-      "dev": true,
-      "requires": {
-        "node-fetch": "^1.0.1",
-        "whatwg-fetch": ">=0.10.0"
-      },
-      "dependencies": {
-        "is-stream": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
-          "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
-          "dev": true
-        },
-        "node-fetch": {
-          "version": "1.7.3",
-          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.3.tgz",
-          "integrity": "sha512-NhZ4CsKx7cYm2vSrBAr2PvFOe6sWDf0UYLRqA6svUYg7+/TSfVAu49jYC4BvQ4Sms9SZgdqGBgroqfDhJdTyKQ==",
-          "dev": true,
-          "requires": {
-            "encoding": "^0.1.11",
-            "is-stream": "^1.0.1"
-          }
-        }
-      }
     },
     "istanbul-lib-coverage": {
       "version": "3.0.0",
@@ -16376,15 +16112,6 @@
       "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
       "dev": true
     },
-    "promise": {
-      "version": "7.3.1",
-      "resolved": "https://registry.npmjs.org/promise/-/promise-7.3.1.tgz",
-      "integrity": "sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg==",
-      "dev": true,
-      "requires": {
-        "asap": "~2.0.3"
-      }
-    },
     "promise-inflight": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/promise-inflight/-/promise-inflight-1.0.1.tgz",
@@ -20082,12 +19809,6 @@
       "integrity": "sha512-dTEWWNu6JmeVXY0ZYoPuH5cRIwc0MeGbJwah9KUNYSJwommQpCzTySTpEe8Gs1J23aeWEuAobe4Ag7EHVt/LOg==",
       "dev": true
     },
-    "through": {
-      "version": "2.3.8",
-      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
-      "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
-      "dev": true
-    },
     "timers-browserify": {
       "version": "2.0.12",
       "resolved": "https://registry.npmjs.org/timers-browserify/-/timers-browserify-2.0.12.tgz",
@@ -20303,12 +20024,6 @@
       "requires": {
         "is-typedarray": "^1.0.0"
       }
-    },
-    "ua-parser-js": {
-      "version": "0.7.28",
-      "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.28.tgz",
-      "integrity": "sha512-6Gurc1n//gjp9eQNXjD9O3M/sMwVtN5S8Lv9bvOYBfKfDNiIIhqiyi01vMBO45u4zkDE420w/e0se7Vs+sIg+g==",
-      "dev": true
     },
     "unbox-primitive": {
       "version": "1.0.1",
@@ -21389,12 +21104,6 @@
       "requires": {
         "iconv-lite": "0.4.24"
       }
-    },
-    "whatwg-fetch": {
-      "version": "3.6.2",
-      "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-3.6.2.tgz",
-      "integrity": "sha512-bJlen0FcuU/0EMLrdbJ7zOnW6ITZLrZMIarMUVmdKtsGvZna8vxKYaexICWPfZ8qwf9fzNq+UEIZrnSaApt6RA==",
-      "dev": true
     },
     "whatwg-mimetype": {
       "version": "2.3.0",

--- a/package.json
+++ b/package.json
@@ -2,10 +2,11 @@
   "name": "@oxctl/ui-lti",
   "version": "1.2.2",
   "author": "University of Oxford, IT Services",
-  "description": "Common ui components used accross our canvas platforms",
+  "description": "Common UI components that are commonly used for LTI tools in the Canvas LMS",
   "main": "dist/index.js",
-  "module": "dist/index.es.js",
+  "module": "dist/index.js",
   "license": "MIT",
+  "sideEffects": false,
   "scripts": {
     "storybook": "start-storybook -p 6006",
     "build-storybook": "build-storybook",
@@ -47,8 +48,7 @@
     "rollup": "^2.45.2",
     "rollup-plugin-babel": "^4.4.0",
     "rollup-plugin-json": "^4.0.0",
-    "rollup-plugin-peer-deps-external": "^2.2.4",
-    "rollup-plugin-terser": "^7.0.2"
+    "rollup-plugin-peer-deps-external": "^2.2.4"
   },
   "peerDependencies": {
     "@instructure/canvas-theme": ">= 7.0.0",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,21 +1,17 @@
 import babel from 'rollup-plugin-babel';
 import external from "rollup-plugin-peer-deps-external";
-import commonjs from '@rollup/plugin-commonjs';
 import json from 'rollup-plugin-json';
-import { terser } from 'rollup-plugin-terser'
 
 export default [
     {
         input: './src/index.js',
         output: [
             {
-                file: 'dist/index.js',
-                format: 'cjs'
-            }, 
-            {
-                file: 'dist/index.es.js',
+                dir: 'dist',
                 format: 'es',
                 exports: 'named',
+                // This is so that we can have tree shaking working.
+                preserveModules: true
             }
         ],
         plugins: [
@@ -24,9 +20,7 @@ export default [
                 presets: ["@babel/preset-react"]
             }),
             external(),
-            commonjs(),
             json(),
-            terser(),
         ]
     }
 ]


### PR DESCRIPTION
We just produce ES6 Modules now and keep then modules in separate files so that tree shaking can easily identify  which components need to be included in the build.