### PR TITLE
When storing/retrieving token using a string.

### DIFF
--- a/src/components/tokenRetriever/LtiTokenRetriever.js
+++ b/src/components/tokenRetriever/LtiTokenRetriever.js
@@ -87,7 +87,7 @@ export class LtiTokenRetriever extends React.Component {
     // localStorage can be blocked (eg when cookies are blocked)
     try {
       if (jwt) {
-        localStorage.setItem("jwt", jwt)
+        localStorage.setItem("jwt", JSON.stringify(jwt))
       }
     } catch (e) {
       if (!(e instanceof DOMException)) {
@@ -99,7 +99,7 @@ export class LtiTokenRetriever extends React.Component {
   loadJwt = () => {
     // localStorage can be blocked (eg when cookies are blocked)
     try {
-      return localStorage.getItem('jwt')
+      return JSON.parse(localStorage.getItem('jwt'))
     } catch (e) {
       if (!(e instanceof DOMException)) {
         throw e


### PR DESCRIPTION
local storage only supports storing strings so we should convert our JSON to a string first.