### PR TITLE
Switch from build-lib to build.

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ If you want to run storybook over https this looks for a certificate in `localho
 
 Runs library unit tests
 
-### `npm run build-lib`
+### `npm run build`
 
 Builds a new update of the library.
 

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "storybook": "start-storybook -p 6006",
     "storybook-https": "start-storybook -p 6006 --https --ssl-cert localhost.pem --ssl-key localhost-key.pem",
     "build-storybook": "build-storybook",
-    "build-lib": "rollup -cm",
+    "build": "rollup -cm",
     "test": "jest --config ./jest.config.json"
   },
   "files": [


### PR DESCRIPTION
This is more standard and it also means the GitHub Actions will build the library.