### PR TITLE
Switch back to building both CommonJS and ES6

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,8 @@ To publish the library to NPM so that it would be available for usage
 
 ### `npm link`
 
+**This is currently broken**
+
 Before doing this you need to remove any peerDependencies that are in the `node_modules` folder as otherwise you can end up with duplicates in the build and react in particular has problems with this. A quick way to do this is to run:
 
      npm run remove-peers

--- a/package.json
+++ b/package.json
@@ -3,8 +3,8 @@
   "version": "1.3.0",
   "author": "University of Oxford, IT Services",
   "description": "Common UI components that are commonly used for LTI tools in the Canvas LMS",
-  "main": "dist/index.js",
-  "module": "dist/index.js",
+  "main": "dist/cjs/index.js",
+  "module": "dist/es/index.js",
   "license": "MIT",
   "sideEffects": false,
   "scripts": {
@@ -13,8 +13,7 @@
     "build-storybook": "build-storybook",
     "build": "rollup -cm",
     "start": "rollup -cm -w",
-    "test": "jest --config ./jest.config.json",
-    "remove-peers": "npm view --json=true . peerDependencies | jq -r 'keys | .[] |  @text' | while read dep; do  rm -r ./node_modules/${dep} && echo Removed ${dep}; done"
+    "test": "jest --config ./jest.config.json"
   },
   "files": [
     "src/*",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -7,11 +7,15 @@ export default [
         input: './src/index.js',
         output: [
             {
-                dir: 'dist',
+                dir: 'dist/es',
                 format: 'es',
                 exports: 'named',
                 // This is so that we can have tree shaking working.
                 preserveModules: true
+            },
+            {
+                dir: 'dist/cjs',
+                format: 'cjs',
             }
         ],
         plugins: [


### PR DESCRIPTION
This means that npm link doesn't appear to work as when resolving linked modules it appears that our current setup for apps uses the CommonJS version which then only resolves dependencies relative to the linked module.

This switches back to outputting both CommonJS and ES6 so that Jest (which doesn't support ES6 out of the box) can use the CommonJS version of the module.