### PR TITLE
AB#64937 Include the opener on the <form>

### DIFF
--- a/src/components/launchOAuth/LaunchOAuth.js
+++ b/src/components/launchOAuth/LaunchOAuth.js
@@ -71,7 +71,7 @@ export class LaunchOAuth extends React.Component {
           size="large"
           onClick={() => this.handleLogin()}
         />
-        <form ref={this.formRef} method="post" action={proxyServer} target="_blank">
+        <form ref={this.formRef} method="post" action={proxyServer} target="_blank" rel="opener">
           <input type="hidden" name="access_token" value={accessToken ? accessToken : ""}/>
         </form>
       </Fragment> 


### PR DESCRIPTION
If we don't specify that we want the opener passed across to the new window when using the "_blank" target then it is left as null and then we aren't able to refresh to tool after the token has been granted to the tool.