### PR TITLE
AB#65009 Handle message.offset being null

### DIFF
--- a/src/components/heightLimit/LtiHeightLimit.js
+++ b/src/components/heightLimit/LtiHeightLimit.js
@@ -80,7 +80,12 @@ export class LtiHeightLimit extends React.Component {
     }
     if (message.subject === 'lti.fetchWindowSize.response') {
       this.message = message
-      const height = message.height - message.offset.top
+      let height = message.height
+      // When launched from a deep linking placement there doesn't appear to be a offset in the message
+      // returned
+      if (message.offset) {
+        height -= message.offset.top
+      }
       this.setState({height})
       // If we are limiting height we want to resize our height
       this.resize()


### PR DESCRIPTION
When in a deep linking placement the message.offset can be null and therefore we need to test before checking what the top value is.