### PR TITLE
Add PromptOAuth component

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "@instructure/emotion": "^8.2.1",
         "@instructure/ui-avatar": "^8.2.1",
         "@instructure/ui-billboard": "^8.2.1",
+        "@instructure/ui-buttons": "^8.2.1",
         "@instructure/ui-color-picker": "^8.2.1",
         "@instructure/ui-eslint-config": "^8.2.1",
         "@instructure/ui-modal": "^8.2.1",

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "@instructure/emotion": "^8.2.1",
     "@instructure/ui-avatar": "^8.2.1",
     "@instructure/ui-billboard": "^8.2.1",
+    "@instructure/ui-buttons": "^8.2.1",
     "@instructure/ui-color-picker": "^8.2.1",
     "@instructure/ui-eslint-config": "^8.2.1",
     "@instructure/ui-modal": "^8.2.1",

--- a/src/components/promptOAuth/PromptOAuth.js
+++ b/src/components/promptOAuth/PromptOAuth.js
@@ -1,0 +1,95 @@
+import React, {Fragment} from 'react'
+import PropTypes from 'prop-types'
+import {Modal} from "@instructure/ui-modal";
+import {Heading} from "@instructure/ui-heading";
+import {View} from "@instructure/ui-view";
+import {Button} from "@instructure/ui-buttons";
+import {InstUISettingsProvider} from "@instructure/emotion";
+
+/**
+ * Displays a modal asking the user to grant access when requested to.
+ */
+export class PromptOAuth extends React.Component {
+
+    static propTypes = {
+        /**
+         * The token used for requests against the proxy.
+         */
+        accessToken: PropTypes.string,
+        /**
+         * Function called after user has granted the application access to their account.
+         */
+        tokenGranted: PropTypes.func.isRequired,
+        /**
+         * Should we prompt the user to grant access.
+         */
+        needsGrant: PropTypes.bool.isRequired,
+        /**
+         * The proxy server address.
+         */
+        server: PropTypes.string.isRequired,
+        /**
+         * The name of the tool requesting access.
+         */
+        toolName: PropTypes.string
+
+    }
+
+    static defaultProps = {
+        accessToken: "",
+    }
+
+    componentDidMount() {
+        window.addEventListener("message", (event) => {
+            if (event.data === 'token') {
+                this.props.tokenGranted()
+            }
+        }, false)
+    }
+
+    render() {
+
+        const {server, accessToken, needsGrant, tokenGranted, toolName} = this.props
+        const title = toolName ? `Access Required: ${toolName}` : `Access Required`
+        return <>
+            <InstUISettingsProvider
+                theme={{
+                    themeOverrides: {
+                        canvas: {
+                            componentOverrides: {
+                                Mask: {
+                                    // This is to grey out the background behind the modal more so that it's clear
+                                    // what content is waiting on the OAuth grant. For example in the Module Titles
+                                    // there may be other content in the page that doesn't require the granting of 
+                                    // permission
+                                    background: 'rgba( 200, 200, 200, 0.5 )'
+                                }
+                            }
+                        }
+                    }
+                }}
+            >
+                <Modal size='small' label='Access Required' open={needsGrant} as='form'
+                       action={server + "/tokens/check"} method='post' target='_blank' rel='opener'
+                       onDismiss={tokenGranted}
+                >
+                    <Modal.Header>
+                        <Heading level='h3' as='h2'>{title}</Heading>
+                    </Modal.Header>
+                    <Modal.Body>
+                        <View as='div'>
+                            Please grant permission to load this content. This is a one-time (two-step) authorisation.
+                            After clicking you will need to complete one more screen to finish the process.
+                        </View>
+                    </Modal.Body>
+                    <Modal.Footer>
+                        <input type='hidden' name='access_token' value={accessToken}/>
+                        <Button type='submit' color='primary'>Grant Access</Button>
+                    </Modal.Footer>
+                </Modal>
+            </InstUISettingsProvider>
+        </>
+    }
+}
+
+export default PromptOAuth

--- a/src/components/promptOAuth/PromptOAuth.stories.js
+++ b/src/components/promptOAuth/PromptOAuth.stories.js
@@ -1,0 +1,12 @@
+import React, { Fragment } from 'react'
+import { storiesOf } from '@storybook/react';
+import PromptOAuth from "./PromptOAuth";
+
+const stories = storiesOf('Components', module);
+
+stories.add('PromptOAuth', () => {
+    return (<Fragment>
+                <div style={{fontWeight: "bold", paddingTop: "5px"}}> When user needs login</div>       
+                    <PromptOAuth server='https://server.test' needsGrant={true} tokenGranted={()=>{}}/>
+            </Fragment>);
+})

--- a/src/components/promptOAuth/PromptOAuth.test.js
+++ b/src/components/promptOAuth/PromptOAuth.test.js
@@ -1,0 +1,25 @@
+import React from 'react'
+import Adapter from 'enzyme-adapter-react-16';
+import {configure, mount} from 'enzyme';
+import PromptOAuth from "./PromptOAuth";
+import {Button} from "@instructure/ui-buttons";
+
+configure({adapter: new Adapter()});
+
+const setup = (props) => {
+    return mount(<PromptOAuth server='https://server.test' tokenGranted={()=>{}} {...props}/>);
+}
+
+describe('PromptOAuth Test Suite', () => {
+
+    it('Should show a dialog when access is needing granted', () => {
+        const wrapper = setup({needsGrant: true});
+        expect(wrapper.find(Button)).toHaveLength(1)
+        expect(wrapper.text()).toContain("Grant Access")
+    });
+
+    it('Should not show anything when not prompting', () => {
+        const wrapper = setup({needsGrant: false});
+        expect(wrapper.find(Button)).toHaveLength(0);
+    });
+});

--- a/src/index.js
+++ b/src/index.js
@@ -6,3 +6,4 @@ export * from './components/tokenRetriever/LtiTokenRetriever';
 export * from './components/errorBillboard/ErrorBillboard';
 export * from './components/launchOAuth/LaunchOAuth';
 export * from './components/applyTheme/LtiApplyTheme';
+export * from './components/promptOAuth/PromptOAuth';


### PR DESCRIPTION
This allows for the UI of a tool to continue to be shown, but for a prompt to grant access to be overlaid on-top.

This was added as a new component as it's behaviour is quite different to the existing OAuth component in that it doesn't have any child components.