### PR TITLE
Bugfix: If the callback function changes we re-render

### DIFF
--- a/src/components/tokenRetriever/LtiTokenRetriever.jsx
+++ b/src/components/tokenRetriever/LtiTokenRetriever.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from "react";
+import React, { useState, useEffect, useRef } from "react";
 import PropTypes from "prop-types";
 import { Spinner } from '@instructure/ui-spinner';
 import ErrorBillboard from "../errorBillboard/ErrorBillboard.jsx";
@@ -23,7 +23,7 @@ export const LtiTokenRetriever = ({ ltiServer, handleJwt, children, location = w
       const server = getServer();
 
       if (!token) {
-        setState({ loading: false, error: "No token found to load" });
+        setState({ loading: false, error: "No id found to load token with" });
         return;
       }
 
@@ -70,6 +70,25 @@ export const LtiTokenRetriever = ({ ltiServer, handleJwt, children, location = w
 
     fetchToken();
   }, [ltiServer]);
+  
+  // Log a warning if the value of handleJwt changes as it's not how the component should be used.
+  const handleJwtRef = useRef(handleJwt);
+
+  useEffect(() => {
+    if (handleJwtRef.current !== handleJwt) {
+      // Helpful developer warning — prefer using a stable callback (e.g. useCallback) so
+      // the component doesn't see handleJwt as changing every render.
+      try {
+        console.warn(
+          'LtiTokenRetriever: prop `handleJwt` changed. This component should have a stable callback (avoid creating a new function each render, ie useCallback()).'
+        );
+      } catch (e) {
+      }
+    }
+    // Update ref after comparison so initial mount won't trigger the warning.
+    handleJwtRef.current = handleJwt;
+  }, [handleJwt]);
+  
 
   const getToken = () => {
     const params = new URLSearchParams(location.search);

--- a/src/components/tokenRetriever/LtiTokenRetriever.test.jsx
+++ b/src/components/tokenRetriever/LtiTokenRetriever.test.jsx
@@ -34,7 +34,7 @@ describe('LtiTokenRetriever Test Suite', () => {
                 <h1>Mock Child Element</h1>
             </LtiTokenRetriever>
         )
-        expect(screen.getByText('No token found to load')).toBeDefined()
+        expect(screen.getByText('No id found to load token with')).toBeDefined()
     });
 
     it('Should find token in URL', () => {


### PR DESCRIPTION
Currently if the callback function changes then we end up re-loading the token. We shouldn't be doing this because in a functional react component the function might well not be the same between renders.