### PR TITLE
AB#92895 Recalculate height when limit becomes true

### DIFF
--- a/src/components/heightLimit/LtiHeightLimit.jsx
+++ b/src/components/heightLimit/LtiHeightLimit.jsx
@@ -38,6 +38,12 @@ export class LtiHeightLimit extends React.Component {
     this.resize()
   }
 
+  componentDidUpdate(prevProps, prevState) {
+    if (!prevState.limit && this.state.limit) {
+      this.resize()
+    }
+  }
+
   componentWillUnmount() {
     window.removeEventListener('resize', this.resizeListener)
     window.removeEventListener('message', this.messageListener)


### PR DESCRIPTION
The page doesn't rerender when limit changes, so modals aren't positioned accordingly