### PR TITLE
Accept server value directly

### DIFF
--- a/src/components/launchOAuth/LaunchOAuth.jsx
+++ b/src/components/launchOAuth/LaunchOAuth.jsx
@@ -28,7 +28,12 @@ export class LaunchOAuth extends React.Component {
     /**
      * The proxy server address.
      */
-    server: PropTypes.object.isRequired
+    server: PropTypes.oneOfType([
+        PropTypes.shape({
+          proxyServer: PropTypes.string.isRequired
+        }),
+        PropTypes.string
+    ]).isRequired
   }
 
   static defaultProps = {
@@ -59,8 +64,10 @@ export class LaunchOAuth extends React.Component {
     if(promptLogin) {
 
       let proxyServer = ""
-      if(server) {
-          proxyServer = server.proxyServer+ "/tokens/check"
+      if(typeof server === "string") {
+        proxyServer = server + "/tokens/check"
+      } else {
+          proxyServer = server.proxyServer + "/tokens/check"
       }
 
       return <Fragment>

--- a/src/components/launchOAuth/LaunchOAuth.stories.jsx
+++ b/src/components/launchOAuth/LaunchOAuth.stories.jsx
@@ -10,12 +10,12 @@ export default {
 export const Default = {
   render: () => <Fragment>
     <div style={{fontWeight: "bold", paddingTop: "5px"}}> When user does not need login</div>
-    <LaunchOAuth server={{}} promptLogin={false}>
+    <LaunchOAuth server='http://server.example' promptLogin={false}>
       <div> Launch Auth - Not needed</div>
     </LaunchOAuth>
 
     <div style={{fontWeight: "bold", paddingTop: "5px"}}> When user needs login</div>
-    <LaunchOAuth server={{}} promptLogin={true}>
+    <LaunchOAuth server='http://server.example' promptLogin={true}>
       <div> Launch Auth - This would not be rendered</div>
     </LaunchOAuth>
   </Fragment>

--- a/src/components/launchOAuth/LaunchOAuth.test.jsx
+++ b/src/components/launchOAuth/LaunchOAuth.test.jsx
@@ -7,17 +7,31 @@ import {describe, expect, it} from 'vitest'
 describe('LaunchOAuth Test Suite', () => {
 
     it('Should have a child element in component when user not prompted to login', () => {
-        render(<LaunchOAuth server={{}} promptUserLogin={()=>{}} promptLogin={false}>
+        render(<LaunchOAuth server='http://server.test' promptUserLogin={()=>{}} promptLogin={false}>
             <h1>Mock Child Element</h1>
         </LaunchOAuth>)
         expect(screen.getByRole('heading')).toHaveTextContent('Mock Child Element')
     });
 
     it('Should show grant access element in component when user is prompted to login', () => {
-        render(<LaunchOAuth server={{}} promptUserLogin={()=>{}} promptLogin={true}>
+        render(<LaunchOAuth server='http://server.test' promptUserLogin={()=>{}} promptLogin={true}>
             <h1>Mock Child Element</h1>
         </LaunchOAuth>)
         expect(screen.getByRole('button')).toHaveTextContent(/Please Grant Access/)
         expect(screen.queryByText('Mock Child Element')).toBeNull()
     });
+    
+    it('Should show link to authenticate with old configuration', () => {
+        const { container } = render(<LaunchOAuth server={{proxyServer: 'http://server.test'}} promptUserLogin={()=>{}} promptLogin={true}>
+            <h1>Mock Child Element</h1>
+        </LaunchOAuth>)
+        expect(container.querySelector('form').getAttribute('action')).toBe('http://server.test/tokens/check')
+    })
+
+    it('Should show link to authenticate with new configuration', () => {
+        const { container } = render(<LaunchOAuth server={'http://server.test'} promptUserLogin={()=>{}} promptLogin={true}>
+            <h1>Mock Child Element</h1>
+        </LaunchOAuth>)
+        expect(container.querySelector('form').getAttribute('action')).toBe('http://server.test/tokens/check')
+    })
 });


### PR DESCRIPTION
Due to this component being extracted from an application the `server` prop is expected to be a object with a `proxyServer` property, this isn't needed and is confusing to consumers of the application.

This adds support for the `server` prop to be specified directly and makes the component simpler to user. We still support the old format.